### PR TITLE
Added support for GPMDP Now Playing Files

### DIFF
--- a/get/getData.php
+++ b/get/getData.php
@@ -86,7 +86,15 @@ if ((isset($settings["nowplaying_file"]) && !empty($settings["nowplaying_file"])
     if (isset($settings["nowplaying_file"]) && !empty($settings["nowplaying_file"])) {
 		if (file_exists($settings["nowplaying_file"]))
 		{
+			/** If Filename is playback.json will read JSON data for Google Play Music Desktop Player **/
+			if (basename($settings["nowplaying_file"]) == "playback.json")
+			{
+				$json_data = json_decode(file_get_contents($settings["nowplaying_file"]), true);
+				$nowplaying .= $json_data["song"]["title"] . " By: " . $json_data["song"]["artist"];
+			} else {
+			/** Otherwise just output the contents of the file **/
 			$nowplaying .= file_get_contents($settings["nowplaying_file"]);
+			}
 		} else {
 			$nowplaying .= "File doesn't exist";
 		}


### PR DESCRIPTION
check to see if the currently playing file is called playback.json, if it is read the JSON info for a Google Play Music Desktop Player Now Playing file.  I'll admit, this method is kinda hacky and would probably be better done by a checkbox asking if it is a GPMDP file but I just wanted it for my own purposes.
